### PR TITLE
minor DOCS remove unwished space in readme's html

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,6 @@ A Simple Github Action for Cross-Repo Files Synchronization using automatic Pull
     <a href="#license">
         <img src="https://shields.io/badge/license-MIT-%23373737" />
     </a>
-
     <a href="https://godoc.org/github.com/FATMAP/gha-file-sync">
       <img src="https://godoc.org/github.com/FATMAP/gha-file-sync?status.svg" alt="GoDoc">
     </a>


### PR DESCRIPTION
## Description

Just saw my last commit introduced a typo in the html code for badges.
This PR fixes it.