### PR TITLE
minor FIX rename main module to gha-file-sync

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,7 @@
 *.dll
 *.so
 *.dylib
-github-file-sync
+gha-file-sync
 
 # Test binary, built with `go test -c`
 *.test

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ RUN go mod download
 COPY . .
 
 # compile
-RUN go build -o /bin/github-file-sync
+RUN go build -o /bin/gha-file-sync
 
 #
 ## run stage - minimalist final image
@@ -26,6 +26,6 @@ FROM alpine:3.17
 RUN apk add libc6-compat
 
 # get binary from build image
-COPY --from=builder /bin/github-file-sync /bin/github-file-sync
+COPY --from=builder /bin/gha-file-sync /bin/gha-file-sync
 
-ENTRYPOINT ["/bin/github-file-sync"]
+ENTRYPOINT ["/bin/gha-file-sync"]

--- a/action.yml
+++ b/action.yml
@@ -1,4 +1,4 @@
-name: github-file-sync
+name: gha-file-sync
 author: "SlevinWasAlreadyTaken"
 description: "Help to synchronize files between repositories by opening pull requests."
 inputs:

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github-file-sync
+module gha-file-sync
 
 go 1.20
 

--- a/internal/cfg/config.go
+++ b/internal/cfg/config.go
@@ -6,7 +6,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github-file-sync/internal/log"
+	"gha-file-sync/internal/log"
 )
 
 type Config struct {

--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	"github-file-sync/internal/log"
+	"gha-file-sync/internal/log"
 
 	"github.com/google/go-github/github"
 	"golang.org/x/oauth2"

--- a/internal/sync/manager.go
+++ b/internal/sync/manager.go
@@ -5,9 +5,9 @@ import (
 	"fmt"
 	"strings"
 
-	"github-file-sync/internal/cfg"
-	"github-file-sync/internal/github"
-	"github-file-sync/internal/log"
+	"gha-file-sync/internal/cfg"
+	"gha-file-sync/internal/github"
+	"gha-file-sync/internal/log"
 )
 
 // Do synchronize one repository.

--- a/internal/sync/task.go
+++ b/internal/sync/task.go
@@ -7,9 +7,9 @@ import (
 	"regexp"
 	"time"
 
-	"github-file-sync/internal/git"
-	"github-file-sync/internal/github"
-	"github-file-sync/internal/log"
+	"gha-file-sync/internal/git"
+	"gha-file-sync/internal/github"
+	"gha-file-sync/internal/log"
 
 	cp "github.com/otiai10/copy"
 )

--- a/main.go
+++ b/main.go
@@ -4,10 +4,10 @@ import (
 	"context"
 	"os"
 
-	"github-file-sync/internal/cfg"
-	"github-file-sync/internal/github"
-	"github-file-sync/internal/log"
-	"github-file-sync/internal/sync"
+	"gha-file-sync/internal/cfg"
+	"gha-file-sync/internal/github"
+	"gha-file-sync/internal/log"
+	"gha-file-sync/internal/sync"
 )
 
 func main() {


### PR DESCRIPTION
# Description

Historically the module has been named github-file-sync to prevent too much coupling with Github Actions.

Considering the final form of the tool and the repository, I believe we can accept it is coupled to Github Actions and we will see if it evolves in another direction later.

Moreover, this will help fixing the generated go doc.

Fixes https://github.com/FATMAP/gha-file-sync/issues/6