### PR TITLE
minor CHORE warn when github secondary rate limit is reached

### DIFF
--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -23,7 +23,10 @@ func NewClient(ctx context.Context, ghToken string) (*Client, error) {
 	tc := oauth2.NewClient(ctx, ts)
 	// use a rate limiter to handle better the github api limit
 	// focuses on the secondary limit: https://github.com/google/go-github#rate-limiting
-	rateLimiter, err := github_ratelimit.NewRateLimitWaiterClient(tc.Transport)
+	rateLimiter, err := github_ratelimit.NewRateLimitWaiterClient(
+		tc.Transport,
+		github_ratelimit.WithLimitDetectedCallback(LogOnLimitDetected),
+	)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/github/ratelimit.go
+++ b/internal/github/ratelimit.go
@@ -1,0 +1,11 @@
+package github
+
+import (
+	"gha-file-sync/internal/log"
+
+	"github.com/gofri/go-github-ratelimit/github_ratelimit"
+)
+
+func LogOnLimitDetected(ctx *github_ratelimit.CallbackContext) {
+	log.Warnf("secondary rate limit detected, will continue at %v", ctx.SleepUntil)
+}


### PR DESCRIPTION
# Description

Sometimes, jobs get stuck because of the secondary limit is reached and the end-users don't know about when it will continue.

This PR adds a WARN log to inform the end-user when the job will continue to synchronize according that Github Rate Limit information.

# Tests

It looks like this:

```
level=INFO msg="PR created: https://github.com/SlevinWasAlreadyTaken/test8/pull/4"
level=INFO msg="Syncing SlevinWasAlreadyTaken/test9..."
level=INFO msg="-> it has changed!"
level=INFO msg="PR created: https://github.com/SlevinWasAlreadyTaken/test9/pull/4"
level=INFO msg="Syncing SlevinWasAlreadyTaken/test10..."
level=INFO msg="-> it has changed!"
level=INFO msg="PR created: https://github.com/SlevinWasAlreadyTaken/test10/pull/4"
level=INFO msg="Syncing SlevinWasAlreadyTaken/test11..."
level=INFO msg="-> nothing has changed."
level=INFO msg="Syncing SlevinWasAlreadyTaken/test12..."
level=INFO msg="-> it has changed!"
level=WARN msg="secondary rate limit detected, will continue at 2023-06-13 19:02:21 +0200 CEST"
```