### PR TITLE
minor FIX clean the local path before cloning the repo

### DIFF
--- a/internal/git/repository.go
+++ b/internal/git/repository.go
@@ -46,6 +46,10 @@ func NewRepository(
 		authorName: authorName,
 	}
 
+	// first clean any remains for older sync that went wrong
+	// ignore errors
+	_ = r.Clean()
+
 	// try to clone to local path
 	opt := &git.CloneOptions{
 		URL:  r.repoURL,

--- a/internal/sync/manager.go
+++ b/internal/sync/manager.go
@@ -27,7 +27,7 @@ func Do(ctx context.Context, repoFullname string, c *cfg.Config, ghClient *githu
 		c.FilesBindings,
 	)
 	if err != nil {
-		return fmt.Errorf("create repo manager: %v", err)
+		return fmt.Errorf("creating task: %v", err)
 	}
 
 	// ensure we clean data at the end of the sync


### PR DESCRIPTION
# Description

This PR makes the tool more flexible by removing first the local path where it clones the repository.
This will improve local testing and makes the tool more robust overall without any downside.